### PR TITLE
feat: improve typography with Inter font

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,12 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -24,7 +30,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>BlunderBuddy</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,17 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
   darkMode: 'class',


### PR DESCRIPTION
## Summary
- load Inter font from Google Fonts
- configure Tailwind to use Inter as default sans-serif
- apply font across app for cleaner typography

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689afd33570c8325852bb19a8a6001f0

## Summary by Sourcery

Integrate Inter font from Google Fonts, configure Tailwind to use it as the default sans-serif, apply it globally, and update the app title to BlunderBuddy.

Enhancements:
- Add preconnect and Google Fonts stylesheet links for Inter in index.html
- Extend Tailwind config to include Inter in the default sans-serif font stack
- Apply the font-sans utility to the body via a Tailwind base layer
- Update the HTML document title to BlunderBuddy